### PR TITLE
Added dynamic bucket region handling

### DIFF
--- a/cmd/helms3/delete.go
+++ b/cmd/helms3/delete.go
@@ -20,7 +20,7 @@ func (act deleteAction) Run(ctx context.Context) error {
 		return err
 	}
 
-	sess, err := awsutil.Session()
+	sess, err := awsutil.Session(awsutil.DynamicBucketRegion(repoEntry.URL()))
 	if err != nil {
 		return err
 	}

--- a/cmd/helms3/init.go
+++ b/cmd/helms3/init.go
@@ -21,7 +21,7 @@ func (act initAction) Run(ctx context.Context) error {
 		return errors.WithMessage(err, "get index reader")
 	}
 
-	sess, err := awsutil.Session()
+	sess, err := awsutil.Session(awsutil.DynamicBucketRegion(act.uri))
 	if err != nil {
 		return err
 	}

--- a/cmd/helms3/proxy.go
+++ b/cmd/helms3/proxy.go
@@ -18,7 +18,10 @@ type proxyCmd struct {
 const indexYaml = "index.yaml"
 
 func (act proxyCmd) Run(ctx context.Context) error {
-	sess, err := awsutil.Session(awsutil.AssumeRoleTokenProvider(awsutil.StderrTokenProvider))
+	sess, err := awsutil.Session(
+		awsutil.AssumeRoleTokenProvider(awsutil.StderrTokenProvider),
+		awsutil.DynamicBucketRegion(act.uri),
+	)
 	if err != nil {
 		return err
 	}

--- a/cmd/helms3/push.go
+++ b/cmd/helms3/push.go
@@ -44,7 +44,12 @@ func (act pushAction) Run(ctx context.Context) error {
 		return ErrForceAndIgnoreIfExists
 	}
 
-	sess, err := awsutil.Session()
+	repoEntry, err := helmutil.LookupRepoEntry(act.repoName)
+	if err != nil {
+		return err
+	}
+
+	sess, err := awsutil.Session(awsutil.DynamicBucketRegion(repoEntry.URL()))
 	if err != nil {
 		return err
 	}
@@ -66,11 +71,6 @@ func (act pushAction) Run(ctx context.Context) error {
 	// and upload the chart right away.
 
 	chart, err := helmutil.LoadChart(fname)
-	if err != nil {
-		return err
-	}
-
-	repoEntry, err := helmutil.LookupRepoEntry(act.repoName)
 	if err != nil {
 		return err
 	}

--- a/cmd/helms3/reindex.go
+++ b/cmd/helms3/reindex.go
@@ -23,7 +23,7 @@ func (act reindexAction) Run(ctx context.Context) error {
 		return err
 	}
 
-	sess, err := awsutil.Session()
+	sess, err := awsutil.Session(awsutil.DynamicBucketRegion(repoEntry.URL()))
 	if err != nil {
 		return err
 	}

--- a/internal/awsutil/session.go
+++ b/internal/awsutil/session.go
@@ -1,10 +1,14 @@
 package awsutil
 
 import (
+	"log"
+	"net/http/httputil"
+	"net/url"
 	"os"
 
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/aws/session"
+	"github.com/aws/aws-sdk-go/service/s3"
 )
 
 const (
@@ -27,6 +31,72 @@ type SessionOption func(*session.Options)
 func AssumeRoleTokenProvider(provider func() (string, error)) SessionOption {
 	return func(options *session.Options) {
 		options.AssumeRoleTokenProvider = provider
+	}
+}
+
+// DynamicBucketRegion is an option for determining the Helm S3 bucket's AWS
+// region dynamically thus allowing the mixed use of buckets residing in
+// different regions without the need for  manual updating
+// HELM_S3_REGION/AWS_REGION/AWS_DEFAULT_REGION.
+//
+// As the bucket URI will always be using the S3 protocol, this is going to work
+// for S3 bucket chart repositories. THis would not work for HTTPS proxied
+// buckets, because those don't respond to the HEAD request as expected, but
+// that's fine, because the plugin only handles S3 protocols, the regular helm
+// binary can handle HTTPS repositories in such a case.
+func DynamicBucketRegion(bucketURI string) SessionOption {
+	return func(options *session.Options) {
+		parsedBucketURI, err := url.Parse(bucketURI)
+		if err != nil {
+			log.Printf("[WARNING] parsing bucket URI for dynamic bucket region failed, invalid URI: %s\n", bucketURI)
+
+			return
+		}
+
+		// Note: the configured region itself is irrelevant, the endpoint
+		// officially works and returns the bucket region in a response header
+		// regardless of whether the signing region matches the bucket's region,
+		//
+		// Note: the credentials are also irrelevant, because even if the HEAD
+		// bucket request fails and returns non-200 status code indicating no
+		// access to the bucket, the actual bucket region is returned in a
+		// response header.
+		//
+		// Source:
+		// https://github.com/aws/aws-sdk-go/issues/720#issuecomment-243891223.
+		configuration := aws.NewConfig().
+			WithRegion("us-east-1")
+		session := session.Must(session.NewSession())
+		s3Client := s3.New(session, configuration)
+
+		bucketRegionHeader := "X-Amz-Bucket-Region"
+		input := &s3.HeadBucketInput{
+			Bucket: aws.String(parsedBucketURI.Host),
+		}
+		request, _ := s3Client.HeadBucketRequest(input)
+		err = request.Send()
+		if request.HTTPResponse == nil { // Note: only the header part of the response is relevant.
+			requestDump, _ := httputil.DumpRequest(request.HTTPRequest, false)
+			log.Printf(
+				"[WARNING] requesting dynamic bucket region through HEAD bucket failed: %s, request: %s\n",
+				err.Error(),
+				string(requestDump),
+			)
+
+			return
+		} else if len(request.HTTPResponse.Header[bucketRegionHeader]) == 0 {
+			requestDump, _ := httputil.DumpRequest(request.HTTPRequest, false)
+			responseDump, _ := httputil.DumpResponse(request.HTTPResponse, false)
+			log.Printf(
+				"[WARNING] dynamic bucket region header not found in the HEAD bucket response, response: %s\n, request: %s",
+				string(responseDump),
+				string(requestDump),
+			)
+
+			return
+		}
+
+		options.Config.Region = aws.String(request.HTTPResponse.Header[bucketRegionHeader][0])
 	}
 }
 


### PR DESCRIPTION
| Q               | A
| --------------- | ---
| Bug fix?        | no
| New feature?    | yes
| API breaks?     | no
| Deprecations?   | no
| Related tickets | -
| License         | Apache 2.0


### What's in this PR?
<!-- Explain the contents of the PR. Give an overview about the implementation, which decisions were made and why. -->

Added dynamic bucket region handling.

### Why?
<!-- Which problem does the PR fix? (Please remove this section if you linked an issue above) -->

To be able to determine the repo bucket's region dynamically without any additional information than the bucket host URL.

### Additional context
<!-- Additional information we should know about (eg. edge cases, steps you followed to test the implementation) (Please remove this section if you don't need it) -->

The solution uses a `HEAD {bucket-host}` request which returns the region of the bucket in a response header regardless of the signing region and signing credentials. See https://github.com/aws/aws-sdk-go/issues/720#issuecomment-243891223 where it is confirmed as an officially intended behavior.

### Checklist
<!-- Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields. -->

- [X] Code meets the [Developer Guide](https://github.com/banzaicloud/developer-guide)
- ~User guide and development docs updated (if needed)~
- ~Related Helm chart(s) updated (if needed)~

### To Do
<!-- (Please remove this section if you don't need it.) -->
- [X] Reminder: release tag.
- [X] Reminder: make PR to the original repository once tested through Terraform as well.
