### PR TITLE
Added dynamic bucket region session option

### DIFF
--- a/cmd/helms3/delete.go
+++ b/cmd/helms3/delete.go
@@ -34,7 +34,7 @@ func (act deleteAction) Run(ctx context.Context) error {
 		return err
 	}
 
-	sess, err := awsutil.Session()
+	sess, err := awsutil.Session(awsutil.DynamicBucketRegion(repoEntry.URL()))
 	if err != nil {
 		return err
 	}

--- a/cmd/helms3/init.go
+++ b/cmd/helms3/init.go
@@ -35,7 +35,7 @@ func (act initAction) Run(ctx context.Context) error {
 		return errors.WithMessage(err, "get index reader")
 	}
 
-	sess, err := awsutil.Session()
+	sess, err := awsutil.Session(awsutil.DynamicBucketRegion(act.uri))
 	if err != nil {
 		return err
 	}

--- a/cmd/helms3/proxy.go
+++ b/cmd/helms3/proxy.go
@@ -32,7 +32,10 @@ type proxyCmd struct {
 const indexYaml = "index.yaml"
 
 func (act proxyCmd) Run(ctx context.Context) error {
-	sess, err := awsutil.Session(awsutil.AssumeRoleTokenProvider(awsutil.StderrTokenProvider))
+	sess, err := awsutil.Session(
+		awsutil.AssumeRoleTokenProvider(awsutil.StderrTokenProvider),
+		awsutil.DynamicBucketRegion(act.uri),
+	)
 	if err != nil {
 		return err
 	}

--- a/cmd/helms3/push.go
+++ b/cmd/helms3/push.go
@@ -58,7 +58,12 @@ func (act pushAction) Run(ctx context.Context) error {
 		return ErrForceAndIgnoreIfExists
 	}
 
-	sess, err := awsutil.Session()
+	repoEntry, err := helmutil.LookupRepoEntry(act.repoName)
+	if err != nil {
+		return err
+	}
+
+	sess, err := awsutil.Session(awsutil.DynamicBucketRegion(repoEntry.URL()))
 	if err != nil {
 		return err
 	}
@@ -80,11 +85,6 @@ func (act pushAction) Run(ctx context.Context) error {
 	// and upload the chart right away.
 
 	chart, err := helmutil.LoadChart(fname)
-	if err != nil {
-		return err
-	}
-
-	repoEntry, err := helmutil.LookupRepoEntry(act.repoName)
 	if err != nil {
 		return err
 	}

--- a/cmd/helms3/push.go
+++ b/cmd/helms3/push.go
@@ -60,7 +60,7 @@ func (act pushAction) Run(ctx context.Context) error {
 
 	repoEntry, err := helmutil.LookupRepoEntry(act.repoName)
 	if err != nil {
-		return err
+		return errors.Wrapf(err, "looking up repository entry %s failed", act.repoName)
 	}
 
 	sess, err := awsutil.Session(awsutil.DynamicBucketRegion(repoEntry.URL()))

--- a/cmd/helms3/reindex.go
+++ b/cmd/helms3/reindex.go
@@ -37,7 +37,7 @@ func (act reindexAction) Run(ctx context.Context) error {
 		return err
 	}
 
-	sess, err := awsutil.Session()
+	sess, err := awsutil.Session(awsutil.DynamicBucketRegion(repoEntry.URL()))
 	if err != nil {
 		return err
 	}

--- a/internal/awsutil/session.go
+++ b/internal/awsutil/session.go
@@ -15,10 +15,14 @@
 package awsutil
 
 import (
+	"net/url"
 	"os"
 
+	"emperror.dev/errors"
 	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/aws/credentials"
 	"github.com/aws/aws-sdk-go/aws/session"
+	"github.com/aws/aws-sdk-go/service/s3"
 )
 
 const (
@@ -41,6 +45,68 @@ type SessionOption func(*session.Options)
 func AssumeRoleTokenProvider(provider func() (string, error)) SessionOption {
 	return func(options *session.Options) {
 		options.AssumeRoleTokenProvider = provider
+	}
+}
+
+// DynamicBucketRegion is an option for determining the Helm S3 bucket's AWS
+// region dynamically thus allowing the mixed use of buckets residing in
+// different regions without requiring manual updates on the HELM_S3_REGION,
+// AWS_REGION, or AWS_DEFAULT_REGION environment variables.
+//
+// This HEAD bucket solution works with all kinds of S3 URIs containing
+// the bucket name in the host part.
+//
+// The basic idea behind the HEAD bucket solution and the "official
+// confirmation" this behavior is expected and supported came from a comment on
+// the AWS SDK Go repository:
+// https://github.com/aws/aws-sdk-go/issues/720#issuecomment-243891223
+func DynamicBucketRegion(s3URL string) SessionOption {
+	return func(options *session.Options) {
+		parsedS3URL, err := url.Parse(s3URL)
+		if err != nil {
+			return
+		}
+
+		// Note: The dummy credentials are required in case no other credential
+		// provider is found, but even if the HEAD bucket request fails and
+		// returns a non-200 status code indicating no access to the bucket, the
+		// actual bucket region is returned in a response header.
+		//
+		// Note: A signing region **MUST** be configured, otherwise the signed
+		// request fails. The configured region itself is irrelevant, the
+		// endpoint officially works and returns the bucket region in a response
+		// header regardless of whether the signing region matches the bucket's
+		// region.
+		//
+		// Note: The default S3 endpoint **MUST** be configured to avoid making
+		// the request region specific thus avoiding regional redirect responses
+		// (301 Permanently moved) on HEAD bucket. This setting is only required
+		// because any other region than "us-east-1" would configure a
+		// region-specific endpoint as well, so it's more safe to explicitly
+		// configure the default endpoint.
+		//
+		// Source:
+		// https://github.com/aws/aws-sdk-go/issues/720#issuecomment-243891223
+		configuration := aws.NewConfig().
+			WithCredentials(credentials.NewStaticCredentials("dummy", "dummy", "")).
+			WithRegion("us-east-1").
+			WithEndpoint("s3.amazonaws.com")
+		awsSession := session.Must(session.NewSession())
+		s3Client := s3.New(awsSession, configuration)
+
+		bucketRegionHeader := "X-Amz-Bucket-Region"
+		input := &s3.HeadBucketInput{ // nolint:exhaustivestruct // Note: optional query elements.
+			Bucket: aws.String(parsedS3URL.Host),
+		}
+		awsRequest, _ := s3Client.HeadBucketRequest(input)
+		_ = awsRequest.Send()
+
+		if awsRequest.HTTPResponse == nil ||
+			len(awsRequest.HTTPResponse.Header[bucketRegionHeader]) == 0 {
+			return
+		}
+
+		options.Config.Region = aws.String(awsRequest.HTTPResponse.Header[bucketRegionHeader][0])
 	}
 }
 

--- a/internal/awsutil/session.go
+++ b/internal/awsutil/session.go
@@ -110,15 +110,16 @@ func DynamicBucketRegion(s3URL string) SessionOption {
 	}
 }
 
-// Session returns an AWS session as described http://docs.aws.amazon.com/sdk-for-go/v1/developer-guide/configuring-sdk.html
-func Session(opts ...SessionOption) (*session.Session, error) {
+// Session returns an AWS session as described
+// http://docs.aws.amazon.com/sdk-for-go/v1/developer-guide/configuring-sdk.html
+func Session(opts ...SessionOption) (awsSession *session.Session, err error) {
 	disableSSL := false
 	if os.Getenv(awsDisableSSL) == "true" {
 		disableSSL = true
 	}
 
-	so := session.Options{
-		Config: aws.Config{
+	so := session.Options{ // nolint:exhaustivestruct // Note: configuration options.
+		Config: aws.Config{ // nolint:exhaustivestruct // Note: configuration options.
 			DisableSSL:       aws.Bool(disableSSL),
 			S3ForcePathStyle: aws.Bool(true),
 			Endpoint:         aws.String(os.Getenv(awsEndpoint)),
@@ -138,5 +139,10 @@ func Session(opts ...SessionOption) (*session.Session, error) {
 		opt(&so)
 	}
 
-	return session.NewSessionWithOptions(so)
+	awsSession, err = session.NewSessionWithOptions(so)
+	if err != nil {
+		return nil, errors.WrapWithDetails(err, "creating session with options failed, options: %s", so)
+	}
+
+	return awsSession, nil
 }

--- a/internal/awsutil/session_test.go
+++ b/internal/awsutil/session_test.go
@@ -17,7 +17,62 @@ package awsutil
 import (
 	"os"
 	"testing"
+
+	"github.com/aws/aws-sdk-go/aws"
+	"github.com/stretchr/testify/require"
 )
+
+func TestDynamicBucketRegion(t *testing.T) { 
+	t.Parallel()
+
+	defaultSession, err := Session()
+	require.NoError(t, err)
+	defaultRegion := aws.StringValue(defaultSession.Config.Region)
+
+	testCases := []struct {
+		caseDescription      string
+		expectedBucketRegion string
+		inputS3URL           string
+	}{
+		{
+			caseDescription:      "existing S3 bucket URL with host only (no key) -> success",
+			expectedBucketRegion: "eu-central-1",
+			inputS3URL:           "s3://eu-test-bucket",
+		},
+		{
+			caseDescription:      "existing S3 bucket URL with key -> success",
+			expectedBucketRegion: "ap-southeast-2",
+			inputS3URL:           "s3://cn-test-bucket/charts/chart-0.1.2.tgz",
+		},
+		{
+			caseDescription:      "invalid URL -> failing URI parsing, no effect (default region)",
+			expectedBucketRegion: defaultRegion,
+			inputS3URL:           "://not/a/URL",
+		},
+		{
+			caseDescription:      "invalid S3 URL -> failing request, no effect (default region)",
+			expectedBucketRegion: defaultRegion,
+			inputS3URL:           "",
+		},
+		{
+			caseDescription:      "not existing S3 URL -> no region header, no effect (default region)",
+			expectedBucketRegion: defaultRegion,
+			inputS3URL:           "s3://not-an-s3-bucket-url",
+		},
+	}
+
+	for _, testCase := range testCases {
+		testCase := testCase
+
+		t.Run(testCase.caseDescription, func(t *testing.T) {
+			t.Parallel()
+
+			actualSession, err := Session(DynamicBucketRegion(testCase.inputS3URL))
+			require.NoError(t, err, "creating session failed")
+			require.Equal(t, testCase.expectedBucketRegion, aws.StringValue(actualSession.Config.Region))
+		})
+	}
+}
 
 func TestSessionWithCustomEndpoint(t *testing.T) {
 	os.Setenv("AWS_ENDPOINT", "foobar:1234")

--- a/internal/awsutil/session_test.go
+++ b/internal/awsutil/session_test.go
@@ -27,6 +27,7 @@ func TestDynamicBucketRegion(t *testing.T) {
 
 	defaultSession, err := Session()
 	require.NoError(t, err)
+
 	defaultRegion := aws.StringValue(defaultSession.Config.Region)
 
 	testCases := []struct {
@@ -74,7 +75,7 @@ func TestDynamicBucketRegion(t *testing.T) {
 	}
 }
 
-func TestSessionWithCustomEndpoint(t *testing.T) {
+func TestSessionWithCustomEndpoint(t *testing.T) { // nolint:paralleltest // Note: requires refactor.
 	os.Setenv("AWS_ENDPOINT", "foobar:1234")
 	os.Setenv("AWS_DISABLE_SSL", "true")
 	os.Setenv("HELM_S3_REGION", "us-west-2")
@@ -95,6 +96,7 @@ func TestSessionWithCustomEndpoint(t *testing.T) {
 	if *s.Config.Region != "us-west-2" {
 		t.Fatalf("Expected to set us-west-2 region")
 	}
+
 	os.Unsetenv("AWS_ENDPOINT")
 	os.Unsetenv("AWS_DISABLE_SSL")
 	os.Unsetenv("HELM_S3_REGION")

--- a/internal/awsutil/token_provider.go
+++ b/internal/awsutil/token_provider.go
@@ -17,13 +17,20 @@ package awsutil
 import (
 	"fmt"
 	"os"
+
+	"emperror.dev/errors"
 )
 
 // StderrTokenProvider implements token provider for AWS SDK.
 func StderrTokenProvider() (string, error) {
 	var v string
-	fmt.Fprintf(os.Stderr, "Assume Role MFA token code: ")
-	_, err := fmt.Fscanln(os.Stderr, &v)
 
-	return v, err
+	fmt.Fprintf(os.Stderr, "Assume Role MFA token code: ")
+
+	_, err := fmt.Fscanln(os.Stderr, &v)
+	if err != nil {
+		return "", errors.Wrap(err, "reading assume role MFA token failed")
+	}
+
+	return v, nil
 }

--- a/test/e2e/fixture_test.go
+++ b/test/e2e/fixture_test.go
@@ -979,6 +979,15 @@ func searchHelmCharts(t *testing.T, repositoryName, chartName string) []helmChar
 	return charts
 }
 
+// setHelmS3Region sets the HELM_S3_REGION environment variable to the specified
+// value.
+func setHelmS3Region(t *testing.T, value string) {
+	t.Helper()
+
+	err := os.Setenv("HELM_S3_REGION", value)
+	require.NoError(t, err, "setting HELM_S3_REGION failed, value: %s", value)
+}
+
 // temporaryDirectoryPath returns a temporary directory path for the specified
 // path elements.
 func temporaryDirectoryPath(pathElements ...string) string {

--- a/test/e2e/helm_fetch_test.go
+++ b/test/e2e/helm_fetch_test.go
@@ -37,3 +37,47 @@ func (testSuite *EndToEndSuite) TestHelmFetch() {
 	fetchHelmChart(testSuite.T(), repositoryName, chart.Name, chart.Version, path.Dir(temporaryLocalChartPath))
 	deleteFile(testSuite.T(), temporaryLocalChartPath)
 }
+
+func (testSuite *EndToEndSuite) TestHelmFetchWithNoRegion() { // nolint:dupl // Note: intentional.
+	testName := path.Base(testSuite.T().Name())
+
+	bucketName := testSuite.AWSS3BucketName(testName)
+	chart := exampleChart
+	s3Client := testSuite.AWSS3Client()
+
+	bucketRepositoryChartPath := helmS3RepositoryChartPath(chart.Name, chart.Version)
+	localChartPath := testChartPath(testSuite.T(), chart.Name, chart.Version)
+	repositoryName := bucketName
+	temporaryLocalChartPath := testSuite.TemporaryPath(testName, helmChartFileName(chart.Name, chart.Version))
+
+	setHelmS3Region(testSuite.T(), "")
+
+	pushHelmS3Chart(testSuite.T(), repositoryName, localChartPath)
+
+	_ = getAWSS3Object(testSuite.T(), s3Client, bucketName, bucketRepositoryChartPath)
+
+	fetchHelmChart(testSuite.T(), repositoryName, chart.Name, chart.Version, path.Dir(temporaryLocalChartPath))
+	deleteFile(testSuite.T(), temporaryLocalChartPath)
+}
+
+func (testSuite *EndToEndSuite) TestHelmFetchWithfixedRegion() { // nolint:dupl // Note: intentional.
+	testName := path.Base(testSuite.T().Name())
+
+	bucketName := testSuite.AWSS3BucketName(testName)
+	chart := exampleChart
+	s3Client := testSuite.AWSS3Client()
+
+	bucketRepositoryChartPath := helmS3RepositoryChartPath(chart.Name, chart.Version)
+	localChartPath := testChartPath(testSuite.T(), chart.Name, chart.Version)
+	repositoryName := bucketName
+	temporaryLocalChartPath := testSuite.TemporaryPath(testName, helmChartFileName(chart.Name, chart.Version))
+
+	setHelmS3Region(testSuite.T(), "ca-central-1")
+
+	pushHelmS3Chart(testSuite.T(), repositoryName, localChartPath)
+
+	_ = getAWSS3Object(testSuite.T(), s3Client, bucketName, bucketRepositoryChartPath)
+
+	fetchHelmChart(testSuite.T(), repositoryName, chart.Name, chart.Version, path.Dir(temporaryLocalChartPath))
+	deleteFile(testSuite.T(), temporaryLocalChartPath)
+}


### PR DESCRIPTION
| Q               | A
| --------------- | ---
| Bug fix?        | no
| New feature?    | yes
| API breaks?     | no
| Deprecations?   | no
| Related tickets | -
| License         | Apache 2.0


### What's in this PR?
<!-- Explain the contents of the PR. Give an overview about the implementation, which decisions were made and why. -->

1. Added an AWS session initialization option for dynamically retrieving the region of the S3 bucket which is used in the helm command.
2. Added unit test cases covering all paths of this option.
3. Updated the calls to the session constructor to use this option.
4. Added end to end test cases for fetch operation using dynamic bucket region.
5. Fixed linter issues in the modified packages to ensure passing checks.

The `HEAD {{bucket}}` request allows querying the bucket's actual region without prior knowledge with the proper configuration.

Unfortunately this behavior is not explicitly documented - or at least I couldn't find it - but the AWS SDK Go team confirmed in an [issue comment](https://github.com/aws/aws-sdk-go/issues/720#issuecomment-243891223) this is an intended and supported behavior of the endpoint.

If the option runs into any issue, it has no effect on the session/configuration as a fallback mechanism. In such a case the plugin's behavior remains the same as before, namely falling back to the `HELM_S3_REGION` environment variable's value or to the corresponding AWS environment variable's value (`AWS_REGION` or `AWS_DEFAULT_REGION`).

### Why?
<!-- Which problem does the PR fix? (Please remove this section if you linked an issue above) -->

Without the correct region being set currently the plugin throws an error:

```shell
fetch from s3 uri=s3://pregnor-helm-s3-repo-test/stable/cadence/cadence-0.18.0.tgz: fetch object from s3: BucketRegionError: incorrect region, the bucket is not in 'us-west-2' region at endpoint ''
        status code: 301, request id: , host id: 
Error: plugin "bin/helms3" exited with error
```

We wanted to allow the plugin to work without manual region setting and also support multiple repositories residing in different regions without updating the regions in-between fetching charts from those repositories. This is especially relevant when the plugin is used in a Terraform environment.

### Additional context
<!-- Additional information we should know about (eg. edge cases, steps you followed to test the implementation) (Please remove this section if you don't need it) -->

The buckets used in the unit tests were found randomly, they are not mine and I do not have access to them, but they fit the test cases perfectly.

### Checklist
<!-- Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields. -->

- [X] Code meets the [Developer Guide](https://github.com/banzaicloud/developer-guide)
- ~User guide and development docs updated (if needed)~
- ~Related Helm chart(s) updated (if needed)~
